### PR TITLE
Add support for randomly generating some contract ABI calls

### DIFF
--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -221,6 +221,7 @@ program.command('generate-trace', 'Generate a transaction trace file using the p
     .option('--transactions <number>', '<number> of transactions to include in the trace', program.INTEGER, undefined, true)
     .option('--file <path>', '<path> to output file', program.STRING, undefined, true)
     .option('--contract <contract>', 'A contract from ["omg", "bittrex", "etherdelta"] for the transaction to call', program.STRING, undefined, false)
+    .option('--contractAddress <contractAddress>', 'Simulated address of the selected contract', program.STRING, undefined, false)
     .action(async (a, o, l) => {
         
 
@@ -242,7 +243,7 @@ program.command('generate-trace', 'Generate a transaction trace file using the p
                 switch(o['contract']) {
                     case "omg":
                         var addr1 = to;
-                        value = BigInt(0); // Txn value for this contract must be 0
+                        value = 0n; // Txn value for this contract must be 0
 
                         const contractvalue = BigInt(Math.floor(Math.random() * 10000 + 1));
                         var valueStr = contractvalue.toString(16);
@@ -252,14 +253,18 @@ program.command('generate-trace', 'Generate a transaction trace file using the p
                         }
                         var addr1Str = addr1.toString(16);
                         // Pad with zeroes
-                        while (addr1Str.length < 64) {
-                            addr1Str = '0' + addr1Str;
+                        addr1Str = addr1Str.padStart(64, '0');
+
+                        if (o['contractAddress'])
+                            to = BigInt(o['contractAddress']);
+                        else {
+                            // This is the Ethereum address of the OMGToken contract
+                            to = 0xd26114cd6EE289AccF82350c8d8487fedB8A0C07n;
                         }
-                        // This is the Ethereum address of the OMGToken contract
-                        to = BigInt('0xd26114cd6EE289AccF82350c8d8487fedB8A0C07');
                         // This is how to construct the ABI call for the `transfer` function in
                         // the OMG contract, which consists of a target addr and a value
                         txnData = Buffer.from('a9059cbb' + addr1Str + valueStr, 'hex');
+                        console.log(txnData.toString('hex'));
                         break;
                     case "bittrex":
                         value = BigInt(Math.floor(Math.random() * 10000 + 1));
@@ -269,16 +274,17 @@ program.command('generate-trace', 'Generate a transaction trace file using the p
 
                         var addr1Str = addr1.toString(16);
                         // Pad with zeroes
-                        while (addr1Str.length < 64) {
-                            addr1Str = '0' + addr1Str;
-                        }
+                        addr1Str = addr1Str.padStart(64, '0');
                         var addr2Str = addr2.toString(16);
                         // Pad with zeroes
-                        while (addr2Str.length < 64) {
-                            addr2Str = '0' + addr2Str;
+                        addr2Str = addr2Str.padStart(64, '0');
+
+                        if (o['contractAddress'])
+                            to = BigInt(o['contractAddress']);
+                        else {
+                            // This is the Ethereum address of the BittrexToken contract
+                            to = 0xE94b04a0FeD112f3664e45adb2B8915693dD5FF3n;
                         }
-                        // This is the Ethereum address of the BittrexToken contract
-                        to = BigInt('0xE94b04a0FeD112f3664e45adb2B8915693dD5FF3');
                         // This is how to construct the ABI call for the `split` function in
                         // the Bittrex contract, which consists of 2 addr parameters
                         txnData = Buffer.from('0f2c9329' + addr1Str + addr2Str, 'hex');


### PR DESCRIPTION
We need a way to generate synthetic contract calls. This PR adds that functionality to the `generate-trace` command. In particular, the command can now create transactions whose data buffers are loaded with correctly-formatted ABI calls to one of 2 existing contracts in Ethereum: OMGtoken and Bittrex. For each generated contract call, the command generates 1 or more random addresses as parameters to the call, as well as a random value, for the OMGtoken contract.